### PR TITLE
move away from manifest parse for thumbnail

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,13 +56,13 @@ module ApplicationHelper
 
   def thumbnail_from_manifest document, image_options = {}
     manifest = IIIF::Service.parse(document['manifest'])
-    image_tag manifest.thumbnail
+    image_tag "#{document['thumbnail_base']}/full/!200,200/0/default.png"
   end
 
   def first_id_from_manfiest document, image_options = {}
-    manifest = IIIF::Service.parse(document['manifest'])
-    canvas = manifest.sequences.first.canvases.first
-    id = canvas.images.first.resource.service['@id']
-    id
+    #manifest = IIIF::Service.parse(document['manifest'])
+    #canvas = manifest.sequences.first.canvases.first
+    #id = canvas.images.first.resource.service['@id']
+    document['thumbnail_base']
   end
 end

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -579,6 +579,9 @@
    <field name="ttl" type="string" indexed="false" stored="true" multiValued="false"/>
    <field name="manifest" type="string" indexed="false" stored="true" multiValued="false"/>
 
+   <!-- thumbnails -->
+   <field name="thumbnail_base" type="string" indexed="false" stored="true" multiValued="false"/>
+
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -230,7 +230,8 @@
          subject_label,
          language_label,
          manifest,
-         ttl
+         ttl,
+         thumbnail_base
        </str>
 
        <str name="facet">true</str>
@@ -424,7 +425,7 @@
         subtitle_display,
         subtitle_vern_display,
         url_fulltext_display,
-        url_suppl_display,
+        url_suppl_display
       </str>
       
       <str name="facet">true</str>


### PR DESCRIPTION
Requires new solr conf and schema to be put in place after deployment for thumbnail_base to show up.
