### PR TITLE
Update Cap setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,10 +54,10 @@ gem "simple_form"
 gem 'mysql2', '>= 0.3.13', "< 0.4.0"
 
 # Use Capistrano for deployment
-gem 'capistrano', '~> 3.3.5'
+gem 'capistrano', '~> 3.4.0'
 gem 'capistrano-rails'
 gem 'capistrano-bundler'
-gem 'capistrano-passenger', '~> 0.0.5'
+gem 'capistrano-passenger'
 
 gem "devise"
 gem "devise-guests", "~> 0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,20 +74,18 @@ GEM
       sass (~> 3.3)
       sassy-maps (< 1.0.0)
     builder (3.2.2)
-    capistrano (3.3.5)
-      capistrano-stats (~> 1.1.0)
+    capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-passenger (0.0.5)
+    capistrano-passenger (0.1.1)
       capistrano (~> 3.0)
     capistrano-rails (1.1.5)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-stats (1.1.1)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -375,9 +373,9 @@ DEPENDENCIES
   bourbon
   breakpoint
   bundler (>= 1.7.0)
-  capistrano (~> 3.3.5)
+  capistrano (~> 3.4.0)
   capistrano-bundler
-  capistrano-passenger (~> 0.0.5)
+  capistrano-passenger
   capistrano-rails
   capybara (~> 2.4.4)
   coffee-rails (~> 4.0.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,10 @@ set :linked_dirs, fetch(:linked_dirs, []).push('tmp/pids', 'tmp/cache', 'tmp/soc
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+# Force passenger to use touch tmp/restart.txt instead of
+# passenger-config restart-app which requires sudo access
+set :passenger_restart_with_touch, true
+
 namespace :deploy do
 
   after :restart, :clear_cache do


### PR DESCRIPTION
Upgrade to latest passenger capistrano integration and force restart using a non-sudo directive until Passenger 5 is installed installed in the server environment. Passenger 5 does not require sudo access to run 

```
passenger-config restart-app
```

```
set :passenger_restart_with_touch, true
```

Forces cap to use the traditional touch tmp/restart.txt to restart to app upon a deply. 