### PR TITLE
Remove 'whitelist' from comment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,6 @@ module LaePublic
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    # Whitelist locales available for the application
     config.i18n.available_locales = [:en, :es, :'pt-BR']
 
     config.assets.paths << Rails.root.join('vendor', 'assets', 'components')


### PR DESCRIPTION
Attempts to edit the comment revealed it was pretty much redundant with
the configuration line, anyway.