### PR TITLE
Pass WORKER_OPTIONS as argument to from_queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,3 +87,14 @@ workflows:
   build_accept_deploy:
     jobs:
       - build
+
+  nightly:
+    jobs:
+      - build
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main

--- a/app/workers/plum_event_handler.rb
+++ b/app/workers/plum_event_handler.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 class PlumEventHandler
   include Sneakers::Worker
-  from_queue SNEAKERS_QUEUE
-  WORKER_OPTIONS.merge(
-    arguments: { 'x-dead-letter-exchange': 'lae-retry' }
-  )
+  from_queue "lae_#{Rails.env}_queue".freeze, WORKER_OPTIONS
 
   def work(msg)
     msg = JSON.parse(msg)

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -19,6 +19,3 @@ WORKER_OPTIONS = {
   amqp_heartbeat: 10,
   retry_timeout: 60 * 1000 # 60 seconds
 }.freeze
-
-# incorporate the env to prevent staging / prod conflicts
-SNEAKERS_QUEUE = "lae_#{Rails.env}_queue".freeze

--- a/spec/features/range_limit_spec.rb
+++ b/spec/features/range_limit_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 RSpec.feature 'Search', type: :feature do
   feature 'date range' do
     scenario 'limits search results' do
-      visit '/catalog?range[date_created_facet][begin]=1990&range[date_created_facet][end]=1992&search_field=all_fields'
+      visit '/catalog?range[date_created_facet][begin]=1990&range[date_created_facet][end]=2018&search_field=all_fields'
       expect(page).to have_selector 'span.from', text: '1990'
-      expect(page).to have_selector 'span.to', text: '1992'
+      expect(page).to have_selector 'span.to', text: '2018'
       expect(page).to have_content 'Remove constraint Date Created'
       within ".blacklight-date_created_facet" do
         expect(page).to have_button "Apply"


### PR DESCRIPTION
Looking at both [dpul]() and [the sneakers max retries example](https://github.com/jondot/sneakers/blob/9780692624c666b6db8266d2d5710f709cb0f2e2/examples/max_retry_handler.rb) it seems clear that these options should be an argument to `from_queue`. It also looks like the retry queues are created automatically, and we don't need to pass the dead letter queue name.

I moved the queue name to the relevant file while I was in here; the
indirection seemed unnecessary.

closes #405
