### PR TITLE
Don't display deprecation warnings in prod logs.

### DIFF
--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+Rails.application.config.after_initialize do
+  Deprecation.default_deprecation_behavior = :silence if Rails.env.production?
+end


### PR DESCRIPTION
They're overwhelming our log aggregation.

Refs pulibrary/pulfalight#1512