### PR TITLE
Add missing google tag manager.

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -13,4 +13,9 @@
     </section>
   <% end %>
 <% end %>
+<% content_for(:head) do %>
+  <% if Rails.env.production? %>
+    <%= render partial: 'shared/analytics' %>
+  <% end %>
+<% end %>
 <%= render template: "layouts/blacklight/base" %>


### PR DESCRIPTION
We were only getting analytics for the home and about pages, because Blacklight was rendering a different layout!